### PR TITLE
Fix TypeScript typings and static asset manifest

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,8 @@
     "strict": true,
     "skipLibCheck": true,
     "lib": [
-      "ESNext"
+      "ESNext",
+      "DOM"
     ],
     "types": ["vite/client"],
     "jsx": "react-jsx",


### PR DESCRIPTION
## Summary
- add missing manifest to serveStatic for static files
- tighten CSV/email/file/report API typings and error handling
- include DOM lib in tsconfig

## Testing
- `npx tsc --noEmit`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bd601dec6c8329bd2fa59153b896d2