### PR TITLE
fix: use Cloudflare static manifest

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,14 +1,18 @@
 import { Hono } from 'hono'
 import { cors } from 'hono/cors'
 import { serveStatic } from 'hono/cloudflare-workers'
+// Cloudflare injects the static content manifest globally at runtime
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore - provided by Cloudflare Workers
+const manifest = globalThis.__STATIC_CONTENT_MANIFEST
 
 const app = new Hono()
 
 // Enable CORS for API endpoints
 app.use('/api/*', cors())
 
-// Serve static files from public/static directory
-app.use('/static/*', serveStatic({ root: './public' }))
+// Serve static files from public directory using Cloudflare manifest
+app.use('/static/*', serveStatic({ root: './public', manifest }))
 
 // Main application HTML
 app.get('/', (c) => {


### PR DESCRIPTION
## Summary
- use Cloudflare-provided static content manifest when serving static assets

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bd6411fc348329939277cbb43451c1