### PR TITLE
fix(ci): install Playwright browsers with Python CLI

### DIFF
--- a/.github/workflows/task-scraping.yml
+++ b/.github/workflows/task-scraping.yml
@@ -56,8 +56,8 @@ jobs:
         pip install playwright asyncio aiohttp cssselect
         pip install scrapy fake-useragent
 
-        # Install browser for Playwright
-        npx playwright install --with-deps chromium
+        # Install browser for Playwright using Python CLI
+        python -m playwright install --with-deps chromium
 
     - name: 📁 Create Output Directory
       run: |


### PR DESCRIPTION
## Summary
- install Playwright browser via `python -m playwright` in scraping workflow

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68beeccf2a6c8329bf10b41c7714b85f