### PR TITLE
Add agent workflow with secret preflight

### DIFF
--- a/.github/workflows/agent.yml
+++ b/.github/workflows/agent.yml
@@ -1,0 +1,90 @@
+name: agent
+on:
+  schedule:
+    - cron: "0 * * * *"        # 例: 毎正時。既存があればそちらを優先
+  workflow_dispatch:
+    inputs:
+      run_mode:
+        description: "housekeeping-only / full"
+        required: false
+        default: "full"
+
+permissions:
+  contents: read
+  actions: write
+
+concurrency:
+  group: agent-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # --- 前検査: OpenAIシークレットがある時だけ本処理を許可 ---
+  preflight:
+    runs-on: ubuntu-latest
+    outputs:
+      ready:   ${{ steps.chk.outputs.ready }}
+      missing: ${{ steps.chk.outputs.missing }}
+    steps:
+      - id: chk
+        shell: bash
+        env:
+          # フォールバック候補（どれか1つ入っていればOK）
+          OPENAI_A: ${{ secrets.OPENAI_API_KEY }}
+          OPENAI_B: ${{ secrets.OPENAI_API_TOKEN }}
+          OPENAI_C: ${{ secrets.OPENAI_KEY }}
+        run: |
+          pick() { [ -n "$1" ] && echo "$1" && return 0 || return 1; }
+          OPENAI="$(pick "$OPENAI_A" || pick "$OPENAI_B" || pick "$OPENAI_C" || true)"
+
+          if [ -z "$OPENAI" ]; then
+            echo "ready=false" >> $GITHUB_OUTPUT
+            echo "missing=OPENAI_API_KEY(or TOKEN/KEY)" >> $GITHUB_OUTPUT
+            echo "⏭️ Missing: OpenAI secret"
+          else
+            echo "ready=true" >> $GITHUB_OUTPUT
+            echo "✅ OpenAI secret present."
+          fi
+
+  # --- 鍵が無い時 or 明示的にhousekeeping要求時 ---
+  housekeeping:
+    needs: preflight
+    if: needs.preflight.outputs.ready == 'false' || github.event.inputs.run_mode == 'housekeeping-only'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: 🧹 Run non-secret tasks
+        shell: bash
+        run: |
+          echo "housekeeping-only (no secrets)"
+          # ここに README整備 / 重複・不要ファイル削除 / md-lint 等を配置（鍵不要のみ）
+
+  # --- 本処理: 鍵がある時だけ動かす。秘密はマスクして環境変数へ ---
+  main:
+    needs: preflight
+    if: needs.preflight.outputs.ready == 'true' && github.event.inputs.run_mode != 'housekeeping-only'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve OpenAI secret safely
+        id: resolve
+        shell: bash
+        env:
+          OPENAI_A: ${{ secrets.OPENAI_API_KEY }}
+          OPENAI_B: ${{ secrets.OPENAI_API_TOKEN }}
+          OPENAI_C: ${{ secrets.OPENAI_KEY }}
+        run: |
+          set -euo pipefail
+          pick() { [ -n "$1" ] && echo "$1" && return 0 || return 1; }
+          OPENAI="$(pick "$OPENAI_A" || pick "$OPENAI_B" || pick "$OPENAI_C" || true)"
+          if [ -z "$OPENAI" ]; then echo "missing OpenAI secret"; exit 1; fi
+          echo "::add-mask::$OPENAI"
+          printf 'OPENAI_API_KEY=%s\n' "$OPENAI" >> "$GITHUB_ENV"
+
+      - name: 🚀 Run tasks that require OpenAI
+        shell: bash
+        run: |
+          # 以降は $OPENAI_API_KEY を利用（絶対にechoしない）
+          echo "full run started"
+          # 実処理をここへ
+

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 kazu-4728
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -40,16 +40,24 @@ curl -X POST \
       "target_url": "https://example.com"
     }
   }'
-```
-
 ## ワークフロー構成
 ```
 .github/workflows/
 ├── agent-main.yml      # オーケストレーター
+├── agent.yml           # OpenAIキー確認・定期実行
 ├── task-scraping.yml   # スクレイピング
 ├── task-pdf-ocr.yml    # PDF/OCR
 └── task-slide-gen.yml  # スライド生成
 ```
+
+## 開発とテスト
+1. 依存のインストール: `npm install`
+2. ビルド: `npm run build`
+3. テスト: `npm test`
+
+### agent ワークフローの使い方
+- `.github/workflows/agent.yml` が毎時実行され、OpenAI のキーが存在するか事前にチェックします。
+- `workflow_dispatch` で `run_mode` を指定し `housekeeping-only` と `full` を切り替えられます。
 
 ## 出力
 ```
@@ -66,4 +74,7 @@ outputs/
 ## サポート
 - [Issues](https://github.com/kazu-4728/office-automation-hub/issues)
 - [Discussions](https://github.com/kazu-4728/office-automation-hub/discussions)
+
+## ライセンス
+MIT License. 詳細は [LICENSE](./LICENSE) を参照してください。
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "build": "vite build",
     "preview": "wrangler pages dev",
     "deploy": "npm run build && wrangler pages deploy",
-    "cf-typegen": "wrangler types --env-interface CloudflareBindings"
+    "cf-typegen": "wrangler types --env-interface CloudflareBindings",
+    "test": "npm run build && node --test"
   },
   "dependencies": {
     "hono": "^4.9.2"

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -1,0 +1,8 @@
+import test from 'node:test'
+import assert from 'node:assert'
+import app from '../dist/_worker.js'
+
+test('GET / should return 200', async () => {
+  const res = await app.request('/');
+  assert.strictEqual(res.status, 200);
+});


### PR DESCRIPTION
## Summary
- add agent workflow that performs a preflight check for OpenAI secrets
- include housekeeping and main jobs
- add basic server test and test script
- document agent workflow usage and add MIT license

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c4b1192c908329822f674e02d3a738