### PR TITLE
agent ワークフローのスケジュールを1日1回に変更

### DIFF
--- a/.github/workflows/agent.yml
+++ b/.github/workflows/agent.yml
@@ -1,7 +1,7 @@
 name: agent
 on:
   schedule:
-    - cron: "0 * * * *"        # 例: 毎正時。既存があればそちらを優先
+    - cron: "0 22 * * *"  # JST 07:00（UTC 前日22:00）
   workflow_dispatch:
     inputs:
       run_mode:


### PR DESCRIPTION
## 概要
- agent ワークフローの cron を JST 07:00 に合わせて1日1回に変更

## テスト
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c73cd74ed08329b7748b735d0feee0